### PR TITLE
Add SetImageFromBytes()

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -1,6 +1,7 @@
 package gosseract
 
 import (
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -35,6 +36,25 @@ func TestClient_SetImage(t *testing.T) {
 	Expect(t, err).ToBe(nil)
 	Expect(t, text).ToBe("otiai10 / gosseract")
 
+}
+
+func TestClient_SetImageFromBytes(t *testing.T) {
+	client := NewClient()
+	defer client.Close()
+
+	content, err := ioutil.ReadFile("./test/data/001-gosseract.png")
+	if err != nil {
+		t.Fatalf("could not read test file")
+	}
+
+	client.Trim = true
+	client.SetImageFromBytes(content)
+
+	client.SetPageSegMode(PSM_SINGLE_BLOCK)
+
+	text, err := client.Text()
+	Expect(t, err).ToBe(nil)
+	Expect(t, text).ToBe("otiai10 / gosseract")
 }
 
 func TestClient_SetWhitelist(t *testing.T) {

--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -46,6 +46,12 @@ void SetImage(TessBaseAPI a, char* imagepath) {
   api->SetImage(image);
 }
 
+void SetImageFromBuffer(TessBaseAPI a, unsigned char* data, int size) {
+  tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
+  Pix *image = pixReadMem(data, (size_t)size);
+  api->SetImage(image);
+}
+
 void SetPageSegMode(TessBaseAPI a, int m) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   tesseract::PageSegMode mode = (tesseract::PageSegMode)m;

--- a/tessbridge.h
+++ b/tessbridge.h
@@ -8,6 +8,7 @@ void Free(TessBaseAPI);
 int Init(TessBaseAPI, char*, char*, char*);
 bool SetVariable(TessBaseAPI, char*, char*);
 void SetImage(TessBaseAPI, char*);
+void SetImageFromBuffer(TessBaseAPI, unsigned char*, int);
 void SetPageSegMode(TessBaseAPI, int);
 int GetPageSegMode(TessBaseAPI);
 char* UTF8Text(TessBaseAPI);


### PR DESCRIPTION
Currently, the only way to set an image to the client is to use a file on the
FS, hence the nice "tempfile" trick on your server/demo project. I use gocv to
identify parts of images to process _via_ OCR and I don't really want to use
the FS for that.

I looked at the underlying `leptonica` lib to know how to get a `Pix` from a
buffer, and I have implemented the method here. Input parameter must be a
buffer containing image data.